### PR TITLE
Handle calling stop more than once.

### DIFF
--- a/lib/metric.js
+++ b/lib/metric.js
@@ -10,6 +10,7 @@ Metric.prototype.start = function() {
 };
 
 Metric.prototype.stop = function() {
+  if (!this.startTime) return;
   var change = process.hrtime(this.startTime);
 
   this.time += change[0] * 1e9 + change[1];


### PR DESCRIPTION
On older versions of node, hrtime gets upset if you call it with undefined.